### PR TITLE
Keyboard bug fix + fixed names

### DIFF
--- a/Sprint0/Commands/CCyclePlayerItemPrevious.cs
+++ b/Sprint0/Commands/CCyclePlayerItemPrevious.cs
@@ -5,9 +5,9 @@ using System.Text;
 
 namespace Sprint0.Commands
 {
-    class CCyclePlayerItemNext : ICommand
+    class CCyclePlayerItemPrevious : ICommand
     {
-        public CCyclePlayerItemNext()
+        public CCyclePlayerItemPrevious()
         {
 
         }

--- a/Sprint0/Commands/CMovePlayerDown.cs
+++ b/Sprint0/Commands/CMovePlayerDown.cs
@@ -5,9 +5,9 @@ using System.Text;
 
 namespace Sprint0.Commands
 {
-    class CMovePlayerUp : ICommand
+    class CMovePlayerDown : ICommand
     {
-        public CMovePlayerUp()
+        public CMovePlayerDown()
         {
 
         }

--- a/Sprint0/Commands/CMovePlayerLeft.cs
+++ b/Sprint0/Commands/CMovePlayerLeft.cs
@@ -5,9 +5,9 @@ using System.Text;
 
 namespace Sprint0.Commands
 {
-    class CMovePlayerUp : ICommand
+    class CMovePlayerLeft : ICommand
     {
-        public CMovePlayerUp()
+        public CMovePlayerLeft()
         {
 
         }

--- a/Sprint0/Commands/CMovePlayerRight.cs
+++ b/Sprint0/Commands/CMovePlayerRight.cs
@@ -5,9 +5,9 @@ using System.Text;
 
 namespace Sprint0.Commands
 {
-    class CMovePlayerUp : ICommand
+    class CMovePlayerRight : ICommand
     {
-        public CMovePlayerUp()
+        public CMovePlayerRight()
         {
 
         }

--- a/Sprint0/Controllers/KeyboardController.cs
+++ b/Sprint0/Controllers/KeyboardController.cs
@@ -8,7 +8,6 @@ namespace Sprint0.Controllers
 {
     class KeyboardController : IController
     {
-
         private Dictionary<Keys, ICommand> controllerMappings;
 
         /*
@@ -29,11 +28,12 @@ namespace Sprint0.Controllers
 
             foreach (Keys key in pressedKeys)
             {
+                if (controllerMappings.ContainsKey(key)) // only updates if that key is in the dictionary 
+                {
+                    controllerMappings[key].Execute();
+                }
                 
-                controllerMappings[key].Execute();
             }
         }
-
-
     }
 }

--- a/Sprint0/Interfaces/IEntity.cs
+++ b/Sprint0/Interfaces/IEntity.cs
@@ -10,7 +10,7 @@ namespace Sprint0.Interfaces
     /*
      * This interface can be used for all entities (maybe this is too like ILink in purpose?).
      */
-   public interface IBlock
+   public interface IEntity
     {
         void Update();
     }


### PR DESCRIPTION
Fixed a bug crash where any keyboard input not in the dictionary would crash the program.

Fixed incorrect names for movement and CyclePlayeritem, and IEntity