### PR TITLE
Fixed theme music not stopping on death

### DIFF
--- a/Sprint0/HUD/GameOverScreen.cs
+++ b/Sprint0/HUD/GameOverScreen.cs
@@ -39,7 +39,6 @@ namespace Sprint0.HUD
         }
         public void Draw(SpriteBatch spriteBatch, ICamera camera)
         {
-            soundInfo.StopLoopedSound(LevelFactory.Instance.currentSoundtrack); // this isn't stopping the background music for some reason? i think that StopLoopedSound() needs to be fixed as it's returning false here
             soundInfo.PlaySound("smb_gameover", false);
             spriteBatch.Draw(background, new Rectangle(0, 0, 6750, 600), Color.Black);
            spriteBatch.DrawString(font, "GAMEOVER ", new Vector2(camera.GetPosition().X + camera.GetViewport().Width/ 2, camera.GetPosition().Y + camera.GetViewport().Height / 2), Color.White);

--- a/Sprint0/Levels/LevelFactory.cs
+++ b/Sprint0/Levels/LevelFactory.cs
@@ -52,6 +52,14 @@ namespace Sprint0
             soundInfo.PlaySound(currentSoundtrack, true);
             SetupReader(levelNumber);
         }
+        public void StopTheme()
+        {
+            /*
+             * If we ever have more sounds played by this sound info, this might be changed to
+             * stop all sounds.
+             */
+            soundInfo.StopLoopedSound(currentSoundtrack);
+        }
         public void SetupReader(int levelNumber)
         {
 

--- a/Sprint0/Player/Mario.cs
+++ b/Sprint0/Player/Mario.cs
@@ -60,8 +60,7 @@ namespace Sprint0
              */
             if(healthStateMachine.GetHealth() == "Dead")
             {
-                // this isn't stopping the background music for some reason? i think that StopLoopedSound() needs to be fixed as it's returning false here
-                soundInfo.StopLoopedSound(LevelFactory.Instance.currentSoundtrack);
+                LevelFactory.Instance.StopTheme();
                 soundInfo.PlaySound("smb_mariodie", false);
                 currentSprite = SpriteFactory.Instance.GetSprite("MarioDead");
                 currentState = new DeathState(this);


### PR DESCRIPTION
Added a StopTheme method to the level factory to easily allow the theme music to be stoppped when Mario dies in game.