### PR TITLE
Many small changes, as well as making the star mario sounds good.

### DIFF
--- a/Sprint0/HUD/GameOverScreen.cs
+++ b/Sprint0/HUD/GameOverScreen.cs
@@ -25,8 +25,8 @@ namespace Sprint0.HUD
             gameObject = go;
             font = Game0.Instance.Content.Load<SpriteFont>("Font");
             
-            //reset after 5 seconds
-            Timer resetTimer = new Timer(2000, ResetGame);
+            //reset after 8.75 seconds
+            Timer resetTimer = new Timer(GameUtilities.gameOverTimerFinish, ResetGame);
             resetTimer.StartTimer();
 
             background = Game0.Instance.Content.Load <Texture2D>("GameoverSMB");
@@ -41,7 +41,7 @@ namespace Sprint0.HUD
         {
             soundInfo.PlaySound("smb_gameover", false);
             spriteBatch.Draw(background, new Rectangle(0, 0, 6750, 600), Color.Black);
-           spriteBatch.DrawString(font, "GAMEOVER ", new Vector2(camera.GetPosition().X + camera.GetViewport().Width/ 2, camera.GetPosition().Y + camera.GetViewport().Height / 2), Color.White);
+           spriteBatch.DrawString(font, "GAMEOVER ", new Vector2(camera.GetPosition().X + camera.GetViewport().Width/ 2 - 50, camera.GetPosition().Y + camera.GetViewport().Height / 2), Color.White);
         }
         public void ResetGame(Object source, System.Timers.ElapsedEventArgs e)
         {

--- a/Sprint0/HUD/HUD.cs
+++ b/Sprint0/HUD/HUD.cs
@@ -15,8 +15,8 @@ namespace Sprint0.HUD
         private IHUDState hudState;
         private float initialPlayerPosition;
         private float maxPlayerPosition;
-        private int initialLives = 1;
-        private int lives = 1;
+        private int initialLives = 3;
+        private int lives = 3;
         private int initialScore = 0;
         private int initialCoinCount = 0;
         private int coinCount = 0;

--- a/Sprint0/Items/Item.cs
+++ b/Sprint0/Items/Item.cs
@@ -79,8 +79,7 @@ namespace Sprint0.Items
                     GameObjectManager.Instance.RemoveFromObjectList(this);
                     break;
                 case "Star":
-                    // this isn't stopping the background music for some reason? i think that StopLoopedSound() needs to be fixed as it's returning false here
-                    soundInfo.StopLoopedSound(LevelFactory.Instance.currentSoundtrack);
+                    LevelFactory.Instance.StopTheme();
                     soundInfo.PlaySound("smb_star", false);
                     mario.StarPower();
                     GameObjectManager.Instance.RemoveFromObjectList(this);

--- a/Sprint0/Levels/LevelFactory.cs
+++ b/Sprint0/Levels/LevelFactory.cs
@@ -47,10 +47,14 @@ namespace Sprint0
         }
         public void CreateLevel(int levelNumber)
         {
+            StartTheme();
+            SetupReader(levelNumber);
+        }
+        public void StartTheme()
+        {
             // can possibly make xml later to create sound based on levelNumber
             soundInfo.StopLoopedSound(currentSoundtrack);
             soundInfo.PlaySound(currentSoundtrack, true);
-            SetupReader(levelNumber);
         }
         public void StopTheme()
         {

--- a/Sprint0/Player/State Machines/MarioHealthStateMachine.cs
+++ b/Sprint0/Player/State Machines/MarioHealthStateMachine.cs
@@ -98,6 +98,8 @@ namespace Sprint0
             //invisible for some time after star power
             invincibility = true;
 
+            LevelFactory.Instance.StopTheme();
+
             //remove object after 10000 milliseconds
             Timer invincibilityTimer = new Timer(10000, StarPowerTransition);
             invincibilityTimer.StartTimer();
@@ -142,8 +144,10 @@ namespace Sprint0
         }
         public void StarPowerTransition(Object source, System.Timers.ElapsedEventArgs e)
         {
+            LevelFactory.Instance.StartTheme();
             invincibility = false;
             currentHealth = previousHealth;
+            mario.OnStateChange();
         }
     }
 }

--- a/Sprint0/Player/State Machines/States/DeathState.cs
+++ b/Sprint0/Player/State Machines/States/DeathState.cs
@@ -19,7 +19,7 @@ namespace Sprint0.Concrete_Classes.State_Machines.States
 {
     class DeathState : IMarioState
     {
-        private int timer = 100;
+        private int timer = 120;
         private Vector2 velocity;
         Mario mario;
 

--- a/Sprint0/UtilityClasses/GameUtilities.cs
+++ b/Sprint0/UtilityClasses/GameUtilities.cs
@@ -96,7 +96,7 @@ namespace Sprint0.UtilityClasses
 
 
         //magic number for hud
-         public static double gameOverTimerFinish = 3.5;
+         public static int gameOverTimerFinish = 3500;
 
     }
 }


### PR DESCRIPTION
-Added a Start Theme Method to LevelFactory for star Mario
-Made star Mario theme actually stop and start the current soundtrack
-Made the gameover scene long enough to actually get the whole sound
-Gave Mario 3 lives to start off with instead of one
- Centered the gameover text for the gameover screen
- got rid of a magic number in gameover screen
- added in the onStateChange for star Mario, as it was not put in after the timer change